### PR TITLE
Fix quotations

### DIFF
--- a/content_script.js
+++ b/content_script.js
@@ -69,7 +69,7 @@ class HTMLSerializer {
 
       var win = element.ownerDocument.defaultView;
       var style = win.getComputedStyle(element, null).cssText;
-      style = style.replace(/"/g, this.getQuotes(this.getDepth(window)+1));
+      style = style.replace(/"/g, this.escapedQuote(this.getDepth(window)+1));
       var quotes = this.getQuotes(this.getDepth(window));
       this.html.push(`style=${quotes}${style}${quotes} `);
 
@@ -174,7 +174,7 @@ class HTMLSerializer {
    * @param {number} depth The number of parent windows.
    * @return {string} The correctly escaped quotation marks.
    */
-  getQuotes(depth) {
+  escapedQuote(depth) {
     if (depth == 0) {
       return '"';
     } else {
@@ -217,7 +217,7 @@ function fillSrcHoles(htmlSerializer, callback) {
     }).then(function(blob) {
       var reader = new FileReader();
       reader.onload = function(e) {
-        var quotes = htmlSerializer.getQuotes(htmlSerializer.getDepth(window));
+        var quotes = htmlSerializer.escapedQuote(htmlSerializer.getDepth(window));
         htmlSerializer.html[index] = quotes + e.target.result + quotes;
         fillSrcHoles(htmlSerializer, callback);
       }

--- a/content_script.js
+++ b/content_script.js
@@ -87,7 +87,9 @@ class HTMLSerializer {
             case 'style':
               break;
             default:
-              this.html.push(`${attribute.name}=${quotes}${attribute.value}${quotes} `);
+              var name = attribute.name;
+              var value = attribute.value;
+              this.html.push(`${name}=${quotes}${value}${quotes} `);
           }
         }
         // TODO(sfine): ensure this is working by making sure that an iframe

--- a/content_script.js
+++ b/content_script.js
@@ -3,7 +3,7 @@
  * of strings and stores enough state to later asynchronously convert it into an
  * html text file.
  */
- // TODO(sfine): fix 'Identifier "HTMLSerializer" has already been declared'
+ // TODO(sfine): Fix 'Identifier "HTMLSerializer" has already been declared'
  //              error. Check if this is a problem? -> might only happen on
  //              second click.
 class HTMLSerializer {
@@ -14,7 +14,7 @@ class HTMLSerializer {
      *     ignored while serializing a document.
      * @const
      */
-     // TODO(sfine): process links
+     // TODO(sfine): Process links.
     this.FILTERED_TAGS = new Set(['script', 'noscript', 'style', 'link']);
 
     /**
@@ -39,9 +39,9 @@ class HTMLSerializer {
 
     /**
      * @public {Object<number, string>} The keys represent an index in
-     *     |this.html|. The value is a string that uniquely identifies an iframe,
-     *     the serialized contents of which should be placed at that index of
-     *     |this.html|.
+     *     |this.html|. The value is a string that uniquely identifies an
+     *     iframe, the serialized contents of which should be placed at that
+     *     index of |this.html|.
      */
     this.frameHoles = {};
   }
@@ -58,9 +58,9 @@ class HTMLSerializer {
   processTree(element, depth) {
     var tagName = element.tagName;
     if (!tagName && element.nodeType != Node.TEXT_NODE) {
-      // ignore elements that don't have tags and are not text.
+      // Ignore elements that don't have tags and are not text.
     } else if (tagName && this.FILTERED_TAGS.has(tagName.toLowerCase())) {
-      // filter out elements that are in filteredTags.
+      // Filter out elements that are in filteredTags.
     } else if (element.nodeType == Node.TEXT_NODE) {
       this.html.push(element.textContent);
     } else {
@@ -81,8 +81,8 @@ class HTMLSerializer {
               if (tagName.toLowerCase() != 'iframe') {
                 this.html.push(`${attribute.name}=`);
                 this.srcHoles[this.html.length] = attribute.value;
-                this.html.push(''); // entry where data url will go.
-                this.html.push(' '); // add a space before the next attribute.
+                this.html.push(''); // Entry where data url will go.
+                this.html.push(' '); // Add a space before the next attribute.
               }
             case 'style':
               break;
@@ -92,14 +92,14 @@ class HTMLSerializer {
               this.html.push(`${name}=${quotes}${value}${quotes} `);
           }
         }
-        // TODO(sfine): ensure this is working by making sure that an iframe
+        // TODO(sfine): Ensure this is working by making sure that an iframe
         //              will always have attributes.
         if (tagName.toLowerCase() == 'iframe') {
           this.html.push('srcdoc=');
           var path = this.iframeFullyQualifiedName(window);
           var index = this.iframeIndex(element.contentWindow);
           this.frameHoles[this.html.length] = path + '.' + index;
-          this.html.push(''); // entry where the iframe contents will go.
+          this.html.push(''); // Entry where the iframe contents will go.
         }
       }
 
@@ -210,8 +210,9 @@ function fillSrcHoles(htmlSerializer, callback) {
     var index = Object.keys(htmlSerializer.srcHoles)[0];
     var src = htmlSerializer.srcHoles[index];
     delete htmlSerializer.srcHoles[index];
-    // TODO(sfine): only create a data url if the src url is from the same
-    //              origin.
+    // TODO(sfine): Only create a data url if the src url is from the same
+    //              origin. Additionally, process imgs, videos, etc..
+    //              differently.
     fetch(src).then(function(response) {
       return response.blob();
     }).then(function(blob) {
@@ -229,8 +230,8 @@ function fillSrcHoles(htmlSerializer, callback) {
   }
 }
 
-// TODO(sfine): perhaps handle images seperately.  at least store height and width
-
+// TODO(sfine): Perhaps handle images seperately. At least store height and
+//              width.
 /**
  * Send the neccessary HTMLSerializer properties back to the extension.
  *

--- a/content_script.js
+++ b/content_script.js
@@ -175,7 +175,7 @@ class HTMLSerializer {
    * @param {number} depth The number of parent iframes.
    * @return {string} The correctly escaped quotation marks.
    */
-  function getQuotes(depth) {
+  getQuotes(depth) {
     if (depth == 0) {
       return '"';
     } else {

--- a/content_script.js
+++ b/content_script.js
@@ -96,9 +96,8 @@ class HTMLSerializer {
         //              will always have attributes.
         if (tagName.toLowerCase() == 'iframe') {
           this.html.push('srcdoc=');
-          var path = this.iframeFullyQualifiedName(window);
-          var index = this.iframeIndex(element.contentWindow);
-          this.frameHoles[this.html.length] = path + '.' + index;
+          var name = this.iframeFullyQualifiedName(element.contentWindow);
+          this.frameHoles[this.html.length] = name;
           this.html.push(''); // Entry where the iframe contents will go.
         }
       }

--- a/content_script.js
+++ b/content_script.js
@@ -71,7 +71,7 @@ class HTMLSerializer {
       var style = win.getComputedStyle(element, null).cssText;
       var windowDepth = this.windowDepth(window);
       style = style.replace(/"/g, this.escapedQuote(windowDepth+1));
-      var quotes = this.getQuotes(windowDepth);
+      var quotes = this.escapedQuote(windowDepth);
       this.html.push(`style=${quotes}${style}${quotes} `);
 
       var attributes = element.attributes;

--- a/content_script.js
+++ b/content_script.js
@@ -249,5 +249,5 @@ function sendHTMLSerializerToExtension(htmlSerializer) {
 if (typeof IS_TEST === typeof undefined || !IS_TEST) {
   var htmlSerializer = new HTMLSerializer();
   htmlSerializer.processDocument(document);
-  fillSrcHoles(htmlSerializer, sendHTMLSerializerToExtension)
+  fillSrcHoles(htmlSerializer, sendHTMLSerializerToExtension);
 }

--- a/content_script.js
+++ b/content_script.js
@@ -69,8 +69,9 @@ class HTMLSerializer {
 
       var win = element.ownerDocument.defaultView;
       var style = win.getComputedStyle(element, null).cssText;
-      style = style.replace(/"/g, this.escapedQuote(this.getDepth(window)+1));
-      var quotes = this.getQuotes(this.getDepth(window));
+      var windowDepth = this.windowDepth(window);
+      style = style.replace(/"/g, this.escapedQuote(windowDepth+1));
+      var quotes = this.getQuotes(windowDepth);
       this.html.push(`style=${quotes}${style}${quotes} `);
 
       var attributes = element.attributes;
@@ -188,7 +189,7 @@ class HTMLSerializer {
    * @param {Window} win The window to use in the calculation.
    * @return {number} The nesting depth of the window in the frame trees.
    */
-  getDepth(win) {
+  windowDepth(win) {
     return this.iframeFullyQualifiedName(win).split('.').length - 1;
   }
 }
@@ -217,7 +218,8 @@ function fillSrcHoles(htmlSerializer, callback) {
     }).then(function(blob) {
       var reader = new FileReader();
       reader.onload = function(e) {
-        var quotes = htmlSerializer.escapedQuote(htmlSerializer.getDepth(window));
+        var windowDepth = htmlSerializer.windowDepth(window);
+        var quotes = htmlSerializer.escapedQuote(windowDepth);
         htmlSerializer.html[index] = quotes + e.target.result + quotes;
         fillSrcHoles(htmlSerializer, callback);
       }

--- a/content_script.js
+++ b/content_script.js
@@ -168,10 +168,10 @@ class HTMLSerializer {
   }
 
   /**
-   * Calculate the correct quotes that should be used given how many parent
-   * windows a given window has.
+   * Calculate the correct quotes that should be used given the nesting depth of
+   * the window in the frame tree.
    *
-   * @param {number} depth The number of parent windows.
+   * @param {number} depth The nesting depth of this window in the frame tree.
    * @return {string} The correctly escaped quotation marks.
    */
   escapedQuote(depth) {
@@ -183,10 +183,10 @@ class HTMLSerializer {
   }
 
   /**
-   * Calculate number of parent windows a given window has.
+   * Calculate the nesting depth of a window in the frame tree.
    *
    * @param {Window} win The window to use in the calculation.
-   * @return {number} The number of parent windows.
+   * @return {number} The nesting depth of the window in the frame trees.
    */
   getDepth(win) {
     return this.iframeFullyQualifiedName(win).split('.').length - 1;

--- a/content_script.js
+++ b/content_script.js
@@ -122,7 +122,6 @@ class HTMLSerializer {
    * eventually be converted into an html file.
    *
    * @param {Document} doc The Document to serialize.
-   * @public
    */ 
   processDocument(doc) {
     this.html.push('<!DOCTYPE html>\n');

--- a/content_script.js
+++ b/content_script.js
@@ -66,7 +66,7 @@ class HTMLSerializer {
     } else {
       this.html.push(new Array(depth+1).join('  '));
       this.html.push(`<${tagName.toLowerCase()} `);
-;
+
       var win = element.ownerDocument.defaultView;
       var style = win.getComputedStyle(element, null).cssText;
       style = style.replace(/"/g, this.getQuotes(this.getDepth(window)+1));

--- a/popup.js
+++ b/popup.js
@@ -82,13 +82,6 @@ function fillRemainingHoles(messages, i, depth) {
       }
     }
   }
-  var srcHoles = messages[i].srcHoles;
-  for (var index in srcHoles) {
-    if (srcHoles.hasOwnProperty(index)) {
-      var srcIndex = srcHoles[index];
-      html[srcIndex] = quotes + html[srcIndex] + quotes;
-    }
-  }
 }
 
 /**

--- a/popup.js
+++ b/popup.js
@@ -89,11 +89,6 @@ function fillRemainingHoles(messages, i, depth) {
       html[srcIndex] = quotes + html[srcIndex] + quotes;
     }
   }
-  var styleIndices = messages[i].styleIndices;
-  for (var i = 0; i < styleIndices.length; i++) {
-    var style = html[styleIndices[i]];
-    html[styleIndices[i]] = style.replace(/"/g, quotes);
-  }
 }
 
 /**

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -1,9 +1,9 @@
-QUnit.test('getDepth: no parent window', function(assert) {
+QUnit.test('windowDepth: no parent window', function(assert) {
   var serializer = new HTMLSerializer();
-  assert.equal(serializer.getDepth(window), 0);
+  assert.equal(serializer.windowDepth(window), 0);
 });
 
-QUnit.test('getDepth: multiple parent windows', function(assert) {
+QUnit.test('windowDepth: multiple parent windows', function(assert) {
   var serializer = new HTMLSerializer();
   var fixture = document.getElementById('qunit-fixture');
   var childFrame = document.createElement('iframe');
@@ -11,8 +11,8 @@ QUnit.test('getDepth: multiple parent windows', function(assert) {
   var childFrameBody = childFrame.contentDocument.body;
   var grandChildFrame = document.createElement('iframe');
   childFrameBody.appendChild(grandChildFrame);
-  assert.equal(serializer.getDepth(childFrame.contentWindow), 1);
-  assert.equal(serializer.getDepth(grandChildFrame.contentWindow), 2);
+  assert.equal(serializer.windowDepth(childFrame.contentWindow), 1);
+  assert.equal(serializer.windowDepth(grandChildFrame.contentWindow), 2);
 });
 
 QUnit.test('escapedQuote: zero depth', function(assert) {

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -15,16 +15,16 @@ QUnit.test('getDepth: multiple parent windows', function(assert) {
   assert.equal(serializer.getDepth(grandChildFrame.contentWindow), 2);
 });
 
-QUnit.test('getQuotes: zero depth', function(assert) {
+QUnit.test('escapedQuote: zero depth', function(assert) {
   var serializer = new HTMLSerializer();
-  assert.equal(serializer.getQuotes(0), '"');
+  assert.equal(serializer.escapedQuote(0), '"');
 });
 
-QUnit.test('getQuotes: nonzero depth', function(assert) {
+QUnit.test('escapedQuote: nonzero depth', function(assert) {
   var serializer = new HTMLSerializer();
-  assert.equal(serializer.getQuotes(1), '&quot;');
-  assert.equal(serializer.getQuotes(2), '&amp;quot;');
-  assert.equal(serializer.getQuotes(3), '&amp;amp;quot;');
+  assert.equal(serializer.escapedQuote(1), '&quot;');
+  assert.equal(serializer.escapedQuote(2), '&amp;quot;');
+  assert.equal(serializer.escapedQuote(3), '&amp;amp;quot;');
 });
 
 QUnit.test('iframeIndex: single layer', function(assert) {

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -1,11 +1,92 @@
-QUnit.test("processTree with a single node", function(assert) {
+QUnit.test('getDepth: no parent window', function(assert) {
+  var serializer = new HTMLSerializer();
+  assert.equal(serializer.getDepth(window), 0);
+});
+
+QUnit.test('getDepth: multiple parent windows', function(assert) {
+  var serializer = new HTMLSerializer();
+  var fixture = document.getElementById('qunit-fixture');
+  var childFrame = document.createElement('iframe');
+  fixture.appendChild(childFrame);
+  var childFrameBody = childFrame.contentDocument.body;
+  var grandChildFrame = document.createElement('iframe');
+  childFrameBody.appendChild(grandChildFrame);
+  assert.equal(serializer.getDepth(childFrame.contentWindow), 1);
+  assert.equal(serializer.getDepth(grandChildFrame.contentWindow), 2);
+});
+
+QUnit.test('getQuotes: zero depth', function(assert) {
+  var serializer = new HTMLSerializer();
+  assert.equal(serializer.getQuotes(0), '"');
+});
+
+QUnit.test('getQuotes: nonzero depth', function(assert) {
+  var serializer = new HTMLSerializer();
+  assert.equal(serializer.getQuotes(1), '&quot;');
+  assert.equal(serializer.getQuotes(2), '&amp;quot;');
+  assert.equal(serializer.getQuotes(3), '&amp;amp;quot;');
+});
+
+QUnit.test('iframeIndex: single layer', function(assert) {
+  var serializer = new HTMLSerializer();
+  var fixture = document.getElementById('qunit-fixture');
+  var childFrame1 = document.createElement('iframe');
+  var childFrame2 = document.createElement('iframe');
+  fixture.appendChild(childFrame1);
+  fixture.appendChild(childFrame2);
+  assert.equal(serializer.iframeIndex(window), -1);
+  assert.equal(serializer.iframeIndex(childFrame1.contentWindow), 0);
+  assert.equal(serializer.iframeIndex(childFrame2.contentWindow), 1);
+});
+
+QUnit.test('iframeIndex: multiple layers', function(assert) {
+  var serializer = new HTMLSerializer();
+  var fixture = document.getElementById('qunit-fixture');
+  var childFrame = document.createElement('iframe');
+  var grandChildFrame1 = document.createElement('iframe');
+  var grandChildFrame2 = document.createElement('iframe');
+  fixture.appendChild(childFrame);
+  var childFrameBody = childFrame.contentDocument.body;
+  childFrameBody.appendChild(grandChildFrame1);
+  childFrameBody.appendChild(grandChildFrame2);
+  assert.equal(serializer.iframeIndex(grandChildFrame1.contentWindow), 0);
+  assert.equal(serializer.iframeIndex(grandChildFrame2.contentWindow), 1);
+});
+
+QUnit.test('iframeFullyQualifiedName: single layer', function(assert) {
+  var serializer = new HTMLSerializer();
+  var fixture = document.getElementById('qunit-fixture');
+  var childFrame1 = document.createElement('iframe');
+  var childFrame2 = document.createElement('iframe');
+  fixture.appendChild(childFrame1);
+  fixture.appendChild(childFrame2);
+  assert.equal(serializer.iframeFullyQualifiedName(window), '0');
+  assert.equal(serializer.iframeFullyQualifiedName(childFrame1.contentWindow), '0.0');
+  assert.equal(serializer.iframeFullyQualifiedName(childFrame2.contentWindow), '0.1');
+});
+
+QUnit.test('iframeFullyQualifiedName: multiple layers', function(assert) {
+  var serializer = new HTMLSerializer();
+  var fixture = document.getElementById('qunit-fixture');
+  var childFrame = document.createElement('iframe');
+  var grandChildFrame1 = document.createElement('iframe');
+  var grandChildFrame2 = document.createElement('iframe');
+  fixture.appendChild(childFrame);
+  var childFrameBody = childFrame.contentDocument.body;
+  childFrameBody.appendChild(grandChildFrame1);
+  childFrameBody.appendChild(grandChildFrame2);
+  assert.equal(serializer.iframeFullyQualifiedName(grandChildFrame1.contentWindow), '0.0.0');
+  assert.equal(serializer.iframeFullyQualifiedName(grandChildFrame1.contentWindow), '0.0.0');
+  assert.equal(serializer.iframeFullyQualifiedName(grandChildFrame2.contentWindow), '0.0.1');
+});
+
+QUnit.test('processTree: single node', function(assert) {
   var fixture = document.getElementById('qunit-fixture');
   var node = document.createElement('div');
   node.appendChild(document.createTextNode('test'));
   fixture.appendChild(node);
-  var html = new HTMLSerializer();
-  html.processTree(node, 0);
-  assert.equal(0, Object.keys(html.srcHoles).length);
-  assert.equal(0, Object.keys(html.frameHoles).length);
-  assert.equal(1, html.styleIndices.length);
+  var serializer = new HTMLSerializer();
+  serializer.processTree(node, 0);
+  assert.equal(Object.keys(serializer.srcHoles).length, 0);
+  assert.equal(Object.keys(serializer.frameHoles).length, 0);
 });


### PR DESCRIPTION
There are two primary changes in this pull request.  The first that all of the quotation mark logic was moved from popup.js to content_script.js.  I realized that because I can access the iframe structure cross origin (which I was already doing in iframeFullyQualifiedName), I can determine the quotation marks that I will need before the content_script returns to the extension.  The second is that I added more tests.  I haven't yet tested processTree of processDocument (or anything in popup.js) because I have a few questions about how I'm supposed to do it.  Should I be mocking out the helper methods that I use?
