### PR TITLE
Process srcs

### DIFF
--- a/content_script.js
+++ b/content_script.js
@@ -131,19 +131,19 @@ var HTMLSerializer = class {
     this.html.push(`style=${quote}${style}${quote} `);
 
     var attributes = element.attributes;
-    var attributeSet = new Set();
+    var processedAttributes = new Set();
     if (attributes) {
       for (var i = 0, attribute; attribute = attributes[i]; i++) {
         switch (attribute.name.toLowerCase())  {
           case 'src':
-            this.processSrcAttribute(element, attributeSet);
+            this.processSrcAttribute(element, processedAttributes);
           case 'style':
             break;
           default:
-            if (!attributeSet.has(attribute.name.toLowerCase())) {
+            if (!processedAttributes.has(attribute.name.toLowerCase())) {
               var name = attribute.name;
               var value = attribute.value;
-              this.processSimpleAttribute(name, value, attributeSet);
+              this.processSimpleAttribute(name, value, processedAttributes);
             }
         }
       }
@@ -163,18 +163,18 @@ var HTMLSerializer = class {
    *
    * @param {Element} element The element being processed, which has the src
    *     attribute.
-   * @param {Set<string>} attributeSet The Set containing all attributes already
-   *     added to |this.html| for the Element.
+   * @param {Set<string>} processedAttributes The Set containing all attributes
+   *     already added to |this.html| for the Element.
    * @private
    */
-  processSrcAttribute(element, attributeSet) {
+  processSrcAttribute(element, processedAttributes) {
     var tag = element.tagName.toLowerCase();
     switch(tag) {
       case 'iframe':
         break; // Do nothing.
       case 'source':
         if (!element.parent || element.parent.tagName.toLowerCase() != 'img') {
-          this.processSimpleSrc(element, attributeSet);
+          this.processSimpleSrc(element, processedAttributes);
           break;
         } // else process as img.
       case 'input':
@@ -184,11 +184,11 @@ var HTMLSerializer = class {
         } // else process as img.
       case 'img':
         if (window.location.host == this.fullyQualifiedURL(element).host) {
-          this.processSrcHole(element, attributeSet);
+          this.processSrcHole(element, processedAttributes);
           break;
         }
       default:
-        this.processSimpleSrc(element, attributeSet);
+        this.processSimpleSrc(element, processedAttributes);
     }
   }
 
@@ -208,59 +208,59 @@ var HTMLSerializer = class {
 
   /**
    * Add an entry to |this.srcHoles| so it can be processed asynchronously, and
-   * mark that a src attribute has been added in |attributeSet|.
+   * mark that a src attribute has been added in |processedAttributes|.
    *
    * @param {Element} element The element being processed, which has the src
    *     attribute.
-   * @param {Set<string>} attributeSet The Set containing all attributes already
-   *     added to |this.html| for the Element.
+   * @param {Set<string>} processedAttributes The Set containing all attributes
+   *     already added to |this.html| for the Element.
    * @private
    */
-  processSrcHole(element, attributeSet) {
+  processSrcHole(element, processedAttributes) {
     var src = element.attributes.src;
     this.html.push(`${src.name}=`);
     this.srcHoles[this.html.length] = this.fullyQualifiedURL(element).href;
     this.html.push(''); // Entry where data url will go.
     this.html.push(' '); // Add a space before the next attribute.
-    attributeSet.add('src');
+    processedAttributes.add('src');
   }
 
   /**
-   * Add the src attribute to |this.html| and update |attributeSet|.  If the
-   * height and width attributes are not set, they will be set.
+   * Add the src attribute to |this.html| and update |processedAttributes|.  If
+   * the height and width attributes are not set, they will be set.
    *
    * @param {Element} element The Element with the src attribute.
-   * @param {Set<string>} attributeSet The Set containing all attributes already
-   *     added to |this.html| for the Element.
+   * @param {Set<string>} processedAttributes The Set containing all attributes
+   *     already added to |this.html| for the Element.
    */
-  processSimpleSrc(element, attributeSet) {
+  processSimpleSrc(element, processedAttributes) {
     // TODO(sfine): Ensure that this is working.  Perhaps don't always want to
     //              be setting height and width.
-    if (!attributeSet.has('height')) {
+    if (!processedAttributes.has('height')) {
       var height = element.clientHeight.toString();
-      this.processSimpleAttribute('height', height, attributeSet);
+      this.processSimpleAttribute('height', height, processedAttributes);
     }
-    if (!attributeSet.has('width')) {
+    if (!processedAttributes.has('width')) {
       var width = element.clientWidth.toString();
-      this.processSimpleAttribute('width', width, attributeSet);
+      this.processSimpleAttribute('width', width, processedAttributes);
     }
     var url = this.fullyQualifiedURL(element).href;
-    this.processSimpleAttribute('src', url, attributeSet);
+    this.processSimpleAttribute('src', url, processedAttributes);
   }
 
   /**
    * Add a name and value pair to the list of attributes in |this.html| and
-   * update |attributeSet|.
+   * update |processedAttributes|.
    *
    * @param {string} name The name of the attribute.
    * @param {string} value The value of the attribute.
-   * @param {Set<string>} attributeSet The Set containing all attributes already
-   *     added to |this.html| for the Element.
+   * @param {Set<string>} processedAttributes The Set containing all attributes
+   *     already added to |this.html| for the Element.
    */
-  processSimpleAttribute(name, value, attributeSet) {
+  processSimpleAttribute(name, value, processedAttributes) {
     var quote = this.escapedQuote(this.windowDepth(window));
     this.html.push(`${name}=${quote}${value}${quote} `);
-    attributeSet.add(name.toLowerCase());
+    processedAttributes.add(name.toLowerCase());
   }
 
   /**

--- a/content_script.js
+++ b/content_script.js
@@ -11,7 +11,7 @@ var HTMLSerializer = class {
      *     ignored while serializing a document.
      * @const
      */
-    this.FILTERED_TAGS = new Set(['script', 'noscript', 'style', 'link']);
+    this.FILTERED_TAGS = new Set(['SCRIPT', 'NOSCRIPT', 'STYLE', 'LINK']);
 
     /**
      * @private {Set<string>} Contains the tag names for elements
@@ -73,7 +73,7 @@ var HTMLSerializer = class {
     var tagName = element.tagName;
     if (!tagName && element.nodeType != Node.TEXT_NODE) {
       // Ignore elements that don't have tags and are not text.
-    } else if (tagName && this.FILTERED_TAGS.has(tagName.toLowerCase())) {
+    } else if (tagName && this.FILTERED_TAGS.has(tagName)) {
       // Filter out elements that are in filteredTags.
     } else if (element.nodeType == Node.TEXT_NODE) {
       this.html.push(element.textContent);
@@ -149,7 +149,7 @@ var HTMLSerializer = class {
       }
       // TODO(sfine): Ensure this is working by making sure that an iframe
       //              will always have attributes.
-      if (element.tagName.toLowerCase() == 'iframe') {
+      if (element.tagName == 'IFRAME') {
         this.html.push('srcdoc=');
         var name = this.iframeFullyQualifiedName(element.contentWindow);
         this.frameHoles[this.html.length] = name;
@@ -168,21 +168,21 @@ var HTMLSerializer = class {
    * @private
    */
   processSrcAttribute(element, processedAttributes) {
-    var tag = element.tagName.toLowerCase();
+    var tag = element.tagName;
     switch (tag) {
-      case 'iframe':
+      case 'IFRAME':
         break; // Do nothing.
-      case 'source':
-        if (!element.parent || element.parent.tagName.toLowerCase() != 'img') {
+      case 'SOURCE':
+        if (!element.parent || element.parent.tagName != 'IMG') {
           this.processSimpleSrc(element, processedAttributes);
           break;
         } // else process as img.
-      case 'input':
+      case 'INPUT':
         var type = element.attributes.type;
-        if (tag == 'input' && (!type || type.value.toLowerCase() != 'image')) {
+        if (tag == 'INPUT' && (!type || type.value.toLowerCase() != 'image')) {
           break;
         } // else process as img.
-      case 'img':
+      case 'IMG':
         if (window.location.host == this.fullyQualifiedURL(element).host) {
           this.processSrcHole(element, processedAttributes);
           break;

--- a/content_script.js
+++ b/content_script.js
@@ -324,8 +324,6 @@ function fillSrcHoles(htmlSerializer, callback) {
   }
 }
 
-// TODO(sfine): Perhaps handle images seperately. At least store height and
-//              width.
 /**
  * Send the neccessary HTMLSerializer properties back to the extension.
  *

--- a/content_script.js
+++ b/content_script.js
@@ -169,7 +169,7 @@ var HTMLSerializer = class {
    */
   processSrcAttribute(element, processedAttributes) {
     var tag = element.tagName.toLowerCase();
-    switch(tag) {
+    switch (tag) {
       case 'iframe':
         break; // Do nothing.
       case 'source':

--- a/content_script.js
+++ b/content_script.js
@@ -170,6 +170,8 @@ var HTMLSerializer = class {
   processSrcAttribute(element, attributeSet) {
     var tag = element.tagName.toLowerCase();
     switch(tag) {
+      case 'iframe':
+        break;
       case 'source':
         if (!element.parent || element.parent.tagName.toLowerCase() != 'img') {
           this.processSimpleSrc(element, attributeSet);
@@ -187,7 +189,6 @@ var HTMLSerializer = class {
         }
       default:
         this.processSimpleSrc(element, attributeSet);
-      case 'iframe':
     }
   }
 

--- a/content_script.js
+++ b/content_script.js
@@ -192,19 +192,17 @@ var HTMLSerializer = class {
   }
 
   /**
-   * Get the a URL object for the value of the elements src attribute.
+   * Get a URL object for the value of the elements src attribute.
    *
-   * @param {Element} element The element for which to retrive the URL.
+   * @param {Element} element The element for which to retrieve the URL.
    * @return {URL} The URL object.
    */
-   // TODO(sfine): Ensure that this is robust.
   srcURL(element) {
     var url = element.attributes.src.value;
-    if (url.startsWith('//')) {
-      url = window.location.protocol + url;
-    } else if (url.startsWith('/')) {
-      url = window.location.protocol + '//' + window.location.host + url;
-    }
+    var img = document.createElement('img');
+    img.src = url;
+    url = img.src;
+    img.src = null;
     return new URL(url);
   }
 

--- a/content_script.js
+++ b/content_script.js
@@ -165,7 +165,7 @@ var HTMLSerializer = class {
   processSrcAttribute(element) {
     var win = element.ownerDocument.defaultView;
     var url = this.fullyQualifiedURL(element);
-    var sameOrigin = window.location.host == url.href;
+    var sameOrigin = window.location.host == url.host;
     switch (element.tagName) {
       case 'IFRAME':
         break; // Do nothing.

--- a/content_script.js
+++ b/content_script.js
@@ -163,8 +163,8 @@ var HTMLSerializer = class {
    *
    * @param {Element} element The element being processed, which has the src
    *     attribute.
-   * @param {Set<string>} attributeSet The Set containing all attributes already added
-   *     to the Element.
+   * @param {Set<string>} attributeSet The Set containing all attributes already
+   *     added to the Element.
    * @private
    */
   processSrcAttribute(element, attributeSet) {
@@ -212,8 +212,8 @@ var HTMLSerializer = class {
    *
    * @param {Element} element The element being processed, which has the src
    *     attribute.
-   * @param {Set<string>} attributeSet The Set containing all attributes already added
-   *     to the Element.
+   * @param {Set<string>} attributeSet The Set containing all attributes already
+   *     added to the Element.
    * @private
    */
   processSrcHole(element, attributeSet) {

--- a/content_script.js
+++ b/content_script.js
@@ -38,21 +38,6 @@ var HTMLSerializer = class {
     ]);
 
     /**
-     * @private {Set<string>} Contains the tag names of elements that can have
-     *     height and width attributes.
-     * @const
-     */
-    this.TAGS_WITH_SIZE_ATTRIBUTES = new Set([
-      'CANVAS',
-      'EMBED',
-      'IFRAME',
-      'IMG',
-      'INPUT',
-      'OBJECT',
-      'VIDEO'
-      ]);
-
-    /**
      * @public {Array<string>} This array represents the serialized html that
      *     makes up an element or document. 
      */
@@ -166,14 +151,6 @@ var HTMLSerializer = class {
         var name = this.iframeFullyQualifiedName(element.contentWindow);
         this.frameHoles[this.html.length] = name;
         this.html.push(''); // Entry where the iframe contents will go.
-      }
-      if (this.TAGS_WITH_SIZE_ATTRIBUTES.has(element.tagName)) {
-        if (!attributes.getNamedItem('height')) {
-
-        }
-        if (!attributes.getNamedItem('width')) {
-
-        }
       }
     }
   }

--- a/content_script.js
+++ b/content_script.js
@@ -199,10 +199,9 @@ var HTMLSerializer = class {
    */
   srcURL(element) {
     var url = element.attributes.src.value;
-    var img = document.createElement('img');
-    img.src = url;
-    url = img.src;
-    img.src = null;
+    var a = document.createElement('a');
+    a.href = url;
+    url = a.href; // Retrieve fully qualified URL.
     return new URL(url);
   }
 

--- a/content_script.js
+++ b/content_script.js
@@ -183,7 +183,7 @@ var HTMLSerializer = class {
           break;
         }
       case 'img':
-        if (window.location.host == this.srcURL(element).host) {
+        if (window.location.host == this.fullyQualifiedURL(element).host) {
           this.processSrcHole(element, attributeSet);
           break;
         }
@@ -198,7 +198,7 @@ var HTMLSerializer = class {
    * @param {Element} element The element for which to retrieve the URL.
    * @return {URL} The URL object.
    */
-  srcURL(element) {
+  fullyQualifiedURL(element) {
     var url = element.attributes.src.value;
     var a = document.createElement('a');
     a.href = url;
@@ -219,7 +219,7 @@ var HTMLSerializer = class {
   processSrcHole(element, attributeSet) {
     var src = element.attributes.src;
     this.html.push(`${src.name}=`);
-    this.srcHoles[this.html.length] = this.srcURL(element).href;
+    this.srcHoles[this.html.length] = this.fullyQualifiedURL(element).href;
     this.html.push(''); // Entry where data url will go.
     this.html.push(' '); // Add a space before the next attribute.
     attributeSet.add('src');
@@ -244,7 +244,8 @@ var HTMLSerializer = class {
       var width = element.clientWidth.toString();
       this.processSimpleAttribute('width', width, attributeSet);
     }
-    this.processSimpleAttribute('src', this.srcURL(element).href, attributeSet);
+    var url = this.fullyQualifiedURL(element).href;
+    this.processSimpleAttribute('src', url, attributeSet);
   }
 
   /**

--- a/content_script.js
+++ b/content_script.js
@@ -172,7 +172,7 @@ var HTMLSerializer = class {
     switch(tag) {
       case 'source':
         if (!element.parent || element.parent.tagName.toLowerCase() != 'img') {
-          this.addSimpleSrc(element, attributeSet);
+          this.processSimpleSrc(element, attributeSet);
           break;
         }
       case 'input':
@@ -182,11 +182,11 @@ var HTMLSerializer = class {
         }
       case 'img':
         if (window.location.host == this.srcURL(element).host) {
-          this.addSrcHole(element, attributeSet);
+          this.processSrcHole(element, attributeSet);
           break;
         }
       default:
-        this.addSimpleSrc(element, attributeSet);
+        this.processSimpleSrc(element, attributeSet);
       case 'iframe':
     }
   }
@@ -232,18 +232,18 @@ var HTMLSerializer = class {
    * @param {Set<string>} attributeSet The Set containing all attributes already
    *     added to the Element.
    */
-  addSimpleSrc(element, attributeSet) {
+  processSimpleSrc(element, attributeSet) {
     // TODO(sfine): Ensure that this is working.  Perhaps don't always want to
     //              be setting height and width.
     if (!attributeSet.has('height')) {
       var height = element.clientHeight.toString();
-      this.addSimpleAttribute('height', height, attributeSet);
+      this.processSimpleAttribute('height', height, attributeSet);
     }
     if (!attributeSet.has('width')) {
       var width = element.clientWidth.toString();
-      this.addSimpleAttribute('width', width, attributeSet);
+      this.processSimpleAttribute('width', width, attributeSet);
     }
-    this.addSimpleAttribute('src', this.srcURL(element).href, attributeSet);
+    this.processSimpleAttribute('src', this.srcURL(element).href, attributeSet);
   }
 
   /**

--- a/content_script.js
+++ b/content_script.js
@@ -193,7 +193,7 @@ var HTMLSerializer = class {
   }
 
   /**
-   * Get a URL object for the value of the elements src attribute.
+   * Get a URL object for the value of the |element|'s src attribute.
    *
    * @param {Element} element The element for which to retrieve the URL.
    * @return {URL} The URL object.

--- a/content_script.js
+++ b/content_script.js
@@ -141,7 +141,7 @@ var HTMLSerializer = class {
           default:
             var name = attribute.name;
             var value = attribute.value;
-            this.processSimpleAttribute(name, value);
+            this.processSimpleAttribute(win, name, value);
         }
       }
       // TODO(sfine): Ensure this is working by making sure that an iframe
@@ -163,6 +163,7 @@ var HTMLSerializer = class {
    * @private
    */
   processSrcAttribute(element) {
+    var win = element.ownerDocument.defaultView;
     var url = this.fullyQualifiedURL(element);
     var sameOrigin = window.location.host == url.href;
     switch (element.tagName) {
@@ -173,7 +174,7 @@ var HTMLSerializer = class {
         if (parent && parent.tagName == 'PICTURE' && sameOrigin) {
           this.processSrcHole(element);
         } else {
-          this.processSimpleAttribute('src', url.href);
+          this.processSimpleAttribute(win, 'src', url.href);
         }
         break;
       case 'INPUT':
@@ -186,11 +187,11 @@ var HTMLSerializer = class {
         if (sameOrigin) {
           this.processSrcHole(element);
         } else {
-          this.processSimpleAttribute('src', url.href);
+          this.processSimpleAttribute(win, 'src', url.href);
         }
         break;
       default:
-        this.processSimpleAttribute('src', url.href);
+        this.processSimpleAttribute(win, 'src', url.href);
     }
   }
 
@@ -226,11 +227,12 @@ var HTMLSerializer = class {
   /**
    * Add a name and value pair to the list of attributes in |this.html|.
    *
+   * @param {Window} win The window of the Element that is being processed.
    * @param {string} name The name of the attribute.
    * @param {string} value The value of the attribute.
    */
-  processSimpleAttribute(name, value) {
-    var quote = this.escapedQuote(this.windowDepth(window));
+  processSimpleAttribute(win, name, value) {
+    var quote = this.escapedQuote(this.windowDepth(win));
     this.html.push(`${name}=${quote}${value}${quote} `);
   }
 

--- a/content_script.js
+++ b/content_script.js
@@ -164,7 +164,7 @@ var HTMLSerializer = class {
    * @param {Element} element The element being processed, which has the src
    *     attribute.
    * @param {Set<string>} attributeSet The Set containing all attributes already
-   *     added to the Element.
+   *     added to |this.html| for the Element.
    * @private
    */
   processSrcAttribute(element, attributeSet) {
@@ -213,7 +213,7 @@ var HTMLSerializer = class {
    * @param {Element} element The element being processed, which has the src
    *     attribute.
    * @param {Set<string>} attributeSet The Set containing all attributes already
-   *     added to the Element.
+   *     added to |this.html| for the Element.
    * @private
    */
   processSrcHole(element, attributeSet) {
@@ -231,7 +231,7 @@ var HTMLSerializer = class {
    *
    * @param {Element} element The Element with the src attribute.
    * @param {Set<string>} attributeSet The Set containing all attributes already
-   *     added to the Element.
+   *     added to |this.html| for the Element.
    */
   processSimpleSrc(element, attributeSet) {
     // TODO(sfine): Ensure that this is working.  Perhaps don't always want to
@@ -255,7 +255,7 @@ var HTMLSerializer = class {
    * @param {string} name The name of the attribute.
    * @param {string} value The value of the attribute.
    * @param {Set<string>} attributeSet The Set containing all attributes already
-   *     added to the Element.
+   *     added to |this.html| for the Element.
    */
   processSimpleAttribute(name, value, attributeSet) {
     var quote = this.escapedQuote(this.windowDepth(window));

--- a/content_script.js
+++ b/content_script.js
@@ -171,17 +171,17 @@ var HTMLSerializer = class {
     var tag = element.tagName.toLowerCase();
     switch(tag) {
       case 'iframe':
-        break;
+        break; // Do nothing.
       case 'source':
         if (!element.parent || element.parent.tagName.toLowerCase() != 'img') {
           this.processSimpleSrc(element, attributeSet);
           break;
-        }
+        } // else treat as img.
       case 'input':
         var type = element.attributes.type;
         if (tag == 'input' && (!type || type.value.toLowerCase() != 'image')) {
           break;
-        }
+        } // else treat as img.
       case 'img':
         if (window.location.host == this.fullyQualifiedURL(element).host) {
           this.processSrcHole(element, attributeSet);

--- a/content_script.js
+++ b/content_script.js
@@ -176,12 +176,12 @@ var HTMLSerializer = class {
         if (!element.parent || element.parent.tagName.toLowerCase() != 'img') {
           this.processSimpleSrc(element, attributeSet);
           break;
-        } // else treat as img.
+        } // else process as img.
       case 'input':
         var type = element.attributes.type;
         if (tag == 'input' && (!type || type.value.toLowerCase() != 'image')) {
           break;
-        } // else treat as img.
+        } // else process as img.
       case 'img':
         if (window.location.host == this.fullyQualifiedURL(element).host) {
           this.processSrcHole(element, attributeSet);

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -116,7 +116,6 @@ QUnit.test('processSimpleAttribute: nested window', function(assert) {
   assert.equal(serializer.html[1], 'width=&amp;quot;2&amp;quot; ');
 });
 
-// TODO(sfine): More robustly test this method
 QUnit.test('fullyQualifiedURL', function(assert) {
   var serializer = new HTMLSerializer();
   var iframe = document.createElement('iframe');
@@ -125,7 +124,6 @@ QUnit.test('fullyQualifiedURL', function(assert) {
   assert.equal(window.location.href, url.href);
 });
 
-// TODO(sfine): More robustly test this method
 QUnit.test('processSrcHole: top window', function(assert) {
   var serializer = new HTMLSerializer();
   var iframe = document.createElement('iframe');
@@ -146,10 +144,8 @@ QUnit.test('processSrcAttribute: iframe', function(assert) {
   serializer.processSrcAttribute(iframe);
   assert.equal(serializer.html.length, 0);
   assert.equal(Object.keys(serializer.srcHoles).length, 0);
-  assert.equal(Object.keys(serializer.frameHoles).length, 0);
 });
 
-// TODO(sfine): More robustly test this method
 QUnit.test('processSrcAttribute: audio', function(assert) {
   var serializer = new HTMLSerializer();
   var audio = document.createElement('audio');
@@ -158,7 +154,6 @@ QUnit.test('processSrcAttribute: audio', function(assert) {
   assert.equal(serializer.html[0], `src="${window.location.href}" `);
   assert.equal(serializer.html.length, 1);
   assert.equal(Object.keys(serializer.srcHoles).length, 0);
-  assert.equal(Object.keys(serializer.frameHoles).length, 0);
 });
 
 QUnit.test('processTree: single node', function(assert) {

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -116,37 +116,50 @@ QUnit.test('processSimpleAttribute: nested window', function(assert) {
   assert.equal(serializer.html[1], 'width=&amp;quot;2&amp;quot; ');
 });
 
+// TODO(sfine): More robustly test this method
+QUnit.test('fullyQualifiedURL', function(assert) {
+  var serializer = new HTMLSerializer();
+  var iframe = document.createElement('iframe');
+  iframe.setAttribute('src', 'tests.html');
+  var url = serializer.fullyQualifiedURL(iframe);
+  assert.equal(window.location.href, url.href);
+});
 
-// TODO(sfine): How to test fullyQualifiedURL, if the resource doesn't exist?
-// QUnit.test('fullyQualifiedURL', function(assert) {
-// });
-
-// QUnit.test('processSrcHole: top window', function(assert) {
-//   var serializer = new HTMLSerializer();
-//   var img = document.createElement('img');
-//   img.setAttribute('src', 'url');
-//   serializer.processSrcHole(img);
-//   assert.equal()
-// });
+// TODO(sfine): More robustly test this method
+QUnit.test('processSrcHole: top window', function(assert) {
+  var serializer = new HTMLSerializer();
+  var iframe = document.createElement('iframe');
+  iframe.setAttribute('src', 'tests.html');
+  serializer.processSrcHole(iframe);
+  assert.equal(serializer.html[0], 'src=');
+  assert.equal(serializer.html[1], '');
+  assert.equal(serializer.html[2], ' ');
+  assert.equal(serializer.srcHoles[1], window.location.href);
+  assert.equal(Object.keys(serializer.srcHoles).length, 1);
+  assert.equal(Object.keys(serializer.frameHoles).length, 0);
+});
 
 QUnit.test('processSrcAttribute: iframe', function(assert) {
   var serializer = new HTMLSerializer();
   var iframe = document.createElement('iframe');
-  iframe.setAttribute('src', 'url');
+  iframe.setAttribute('src', 'tests.html');
   serializer.processSrcAttribute(iframe);
   assert.equal(serializer.html.length, 0);
   assert.equal(Object.keys(serializer.srcHoles).length, 0);
   assert.equal(Object.keys(serializer.frameHoles).length, 0);
 });
 
-// TODO(sfine): Test the src attribute, if it will turn it into a full url?
-// QUnit.test('processSrcAttribute: audio', function(assert) {
-//   var serializer = new HTMLSerializer();
-//   var audio = document.createElement('audio');
-//   audio.setAttribute('src', 'url');
-//   serializer.processSrcAttribute(audio);
-//   assert.equal(serializer.html[0], 'src="url" ');
-// });
+// TODO(sfine): More robustly test this method
+QUnit.test('processSrcAttribute: audio', function(assert) {
+  var serializer = new HTMLSerializer();
+  var audio = document.createElement('audio');
+  audio.setAttribute('src', 'tests.html');
+  serializer.processSrcAttribute(audio);
+  assert.equal(serializer.html[0], `src="${window.location.href}" `);
+  assert.equal(serializer.html.length, 1);
+  assert.equal(Object.keys(serializer.srcHoles).length, 0);
+  assert.equal(Object.keys(serializer.frameHoles).length, 0);
+});
 
 QUnit.test('processTree: single node', function(assert) {
   var fixture = document.getElementById('qunit-fixture');

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -191,6 +191,7 @@ QUnit.test('HTMLSerializer class loaded twice', function(assert) {
     done();
   }, 0);
 });
+
 QUnit.test('processTree: no closing tag', function(assert) {
   var serializer = new HTMLSerializer();
   var img = document.createElement('img');
@@ -217,3 +218,53 @@ QUnit.test('processTree: closing tag', function(assert) {
   assert.equal(serializer.html[3], '</p>');
   assert.equal(serializer.html.length, 4);
 });
+
+QUnit.test(
+  'processAttributes: img with height and width attributes',
+  function(assert) {
+    var serializer = new HTMLSerializer();
+    var fixture = document.getElementById('qunit-fixture');
+    var img = document.createElement('img');
+    img.setAttribute('height', 5);
+    img.setAttribute('width', 5);
+    fixture.appendChild(img);
+    serializer.processAttributes(img);
+    var styleText = serializer.html[0];
+    assert.ok(styleText.includes(' height: 5px;'));
+    assert.ok(styleText.includes(' width: 5px;'));
+  }
+);
+
+QUnit.test(
+  'processAttributes: img without height and width attributes',
+  function(assert) {
+    var serializer = new HTMLSerializer();
+    var fixture = document.getElementById('qunit-fixture');
+    var img = document.createElement('img');
+    fixture.appendChild(img);
+    var style = window.getComputedStyle(img, null);
+    serializer.processAttributes(img);
+    var styleText = serializer.html[0];
+    assert.ok(styleText.includes(` height: ${style.height};`));
+    assert.ok(styleText.includes(` width: ${style.width};`));
+  }
+);
+
+QUnit.test(
+  'processAttributes: img with height and width attributes and inline style',
+  function(assert) {
+    var serializer = new HTMLSerializer();
+    var fixture = document.getElementById('qunit-fixture');
+    var img = document.createElement('img');
+    img.setAttribute('height', 5);
+    img.setAttribute('width', 5);
+    img.setAttribute('style', 'height: 10px; width: 10px;');
+    fixture.appendChild(img);
+    serializer.processAttributes(img);
+    var styleText = serializer.html[0];
+    assert.ok(styleText.includes(' height: 10px;'));
+    assert.ok(styleText.includes(' width: 10px;'));
+    assert.notOk(styleText.includes(' height: 5px;'));
+    assert.notOk(styleText.includes(' width: 5px;'));
+  }
+);

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -79,7 +79,6 @@ QUnit.test('iframeFullyQualifiedName: multiple layers', function(assert) {
   var grandChildFrame2 = document.createElement('iframe');
   fixture.appendChild(childFrame);
   var childFrameBody = childFrame.contentDocument.body;
-  console.log(childFrameBody);
   childFrameBody.appendChild(grandChildFrame1);
   childFrameBody.appendChild(grandChildFrame2);
   assert.equal(
@@ -134,7 +133,6 @@ QUnit.test('processSrcHole: top window', function(assert) {
   assert.equal(serializer.html[2], ' ');
   assert.equal(serializer.srcHoles[1], window.location.href);
   assert.equal(Object.keys(serializer.srcHoles).length, 1);
-  assert.equal(Object.keys(serializer.frameHoles).length, 0);
 });
 
 QUnit.test('processSrcAttribute: iframe', function(assert) {
@@ -154,6 +152,18 @@ QUnit.test('processSrcAttribute: audio', function(assert) {
   assert.equal(serializer.html[0], `src="${window.location.href}" `);
   assert.equal(serializer.html.length, 1);
   assert.equal(Object.keys(serializer.srcHoles).length, 0);
+});
+
+QUnit.test('processSrcAttribute: img', function(assert) {
+  var serializer = new HTMLSerializer();
+  var img = document.createElement('img');
+  img.setAttribute('src', 'tests.html');
+  serializer.processSrcAttribute(img);
+  assert.equal(serializer.html[0], 'src=');
+  assert.equal(serializer.html[1], '');
+  assert.equal(serializer.html[2], ' ');
+  assert.equal(serializer.srcHoles[1], window.location.href);
+  assert.equal(Object.keys(serializer.srcHoles).length, 1);
 });
 
 QUnit.test('processTree: single node', function(assert) {


### PR DESCRIPTION
There are two main changes in this pull request which are tied together.  The first is refactoring how an element's attributes are processed into a series of helper functions.  The second is processing src attributes differently depending on the element tagName, and whether the url and the current window have the same origin.
