### PR TITLE
Process elements with no closing tag

### DIFF
--- a/content_script.js
+++ b/content_script.js
@@ -26,15 +26,17 @@ class HTMLSerializer {
       'BASE',
       'BR',
       'COL',
-      'COMMAND',
       'EMBED',
       'HR',
       'IMG',
       'INPUT',
+      'KEYGEN',
       'LINK',
       'META',
       'PARAM',
-      'SOURCE'
+      'SOURCE',
+      'TRACK',
+      'WBR'
     ]);
 
     /**

--- a/content_script.js
+++ b/content_script.js
@@ -17,6 +17,27 @@ class HTMLSerializer {
     this.FILTERED_TAGS = new Set(['script', 'noscript', 'style', 'link']);
 
     /**
+     * @private {Set<string>} Contains the tag names for elements
+     *     that have no closing tags.
+     * @const
+     */
+    this.NO_CLOSING_TAGS = new Set([
+      'AREA',
+      'BASE',
+      'BR',
+      'COL',
+      'COMMAND',
+      'EMBED',
+      'HR',
+      'IMG',
+      'INPUT',
+      'LINK',
+      'META',
+      'PARAM',
+      'SOURCE'
+    ]);
+
+    /**
      * @public {Array<string>} This array represents the serialized html that
      *     makes up an element or document. 
      */
@@ -68,7 +89,9 @@ class HTMLSerializer {
         }
       }
 
-      this.html.push(`</${tagName.toLowerCase()}>`);
+      if (!this.NO_CLOSING_TAGS.has(tagName)) {
+        this.html.push(`</${tagName.toLowerCase()}>`);
+      }
     }
   }
 

--- a/content_script.js
+++ b/content_script.js
@@ -18,7 +18,8 @@ class HTMLSerializer {
 
     /**
      * @private {Set<string>} Contains the tag names for elements
-     *     that have no closing tags.
+     *     that have no closing tags.  List of tags taken from:
+     *     https://html.spec.whatwg.org/multipage/syntax.html#void-elements.
      * @const
      */
     this.NO_CLOSING_TAGS = new Set([

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -101,8 +101,6 @@ QUnit.test('processTree: no closing tag', function(assert) {
   );
   assert.equal(serializer.html[2], '>');
   assert.equal(serializer.html.length, 3);
-  assert.equal(Object.keys(serializer.srcHoles).length, 0);
-  assert.equal(Object.keys(serializer.frameHoles).length, 0);
 });
 
 QUnit.test('processTree: closing tag', function(assert) {
@@ -117,6 +115,4 @@ QUnit.test('processTree: closing tag', function(assert) {
   assert.equal(serializer.html[2], '>');
   assert.equal(serializer.html[3], '</p>');
   assert.equal(serializer.html.length, 4);
-  assert.equal(Object.keys(serializer.srcHoles).length, 0);
-  assert.equal(Object.keys(serializer.frameHoles).length, 0);
 });

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -89,3 +89,34 @@ QUnit.test('processTree: single node', function(assert) {
   assert.equal(Object.keys(serializer.srcHoles).length, 0);
   assert.equal(Object.keys(serializer.frameHoles).length, 0);
 });
+
+QUnit.test('processTree: no closing tag', function(assert) {
+  var serializer = new HTMLSerializer();
+  var img = document.createElement('img');
+  serializer.processTree(img);
+  assert.equal(serializer.html[0], '<img ');
+  assert.equal(
+    serializer.html[1],
+    `style="${window.getComputedStyle(img, null).cssText}" `
+  );
+  assert.equal(serializer.html[2], '>');
+  assert.equal(serializer.html.length, 3);
+  assert.equal(Object.keys(serializer.srcHoles).length, 0);
+  assert.equal(Object.keys(serializer.frameHoles).length, 0);
+});
+
+QUnit.test('processTree: closing tag', function(assert) {
+  var serializer = new HTMLSerializer();
+  var p = document.createElement('p');
+  serializer.processTree(p);
+  assert.equal(serializer.html[0], '<p ');
+  assert.equal(
+    serializer.html[1],
+    `style="${window.getComputedStyle(p, null).cssText}" `
+  );
+  assert.equal(serializer.html[2], '>');
+  assert.equal(serializer.html[3], '</p>');
+  assert.equal(serializer.html.length, 4);
+  assert.equal(Object.keys(serializer.srcHoles).length, 0);
+  assert.equal(Object.keys(serializer.frameHoles).length, 0);
+});


### PR DESCRIPTION
The added functionality in this pull request is to simply not add a closing tag, for elements that should not have them.  (I added corresponding tests! :))
