### PR TITLE
Fix HTMLSerializer has already been declared error

### DIFF
--- a/content_script.js
+++ b/content_script.js
@@ -3,10 +3,7 @@
  * of strings and stores enough state to later asynchronously convert it into an
  * html text file.
  */
- // TODO(sfine): Fix 'Identifier "HTMLSerializer" has already been declared'
- //              error. Check if this is a problem? -> might only happen on
- //              second click.
-class HTMLSerializer {
+var HTMLSerializer = class {
   constructor() {
 
     /**

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -90,6 +90,20 @@ QUnit.test('processTree: single node', function(assert) {
   assert.equal(Object.keys(serializer.frameHoles).length, 0);
 });
 
+QUnit.test('HTMLSerializer class loaded twice', function(assert) {
+  assert.expect(0);
+  var done = assert.async();
+  var fixture = document.getElementById('qunit-fixture');
+  var script1 = document.createElement('script');
+  var script2 = document.createElement('script');
+  script1.setAttribute('src', '../content_script.js');
+  script2.setAttribute('src', '../content_script.js');
+  fixture.appendChild(script1);
+  fixture.appendChild(script2);
+  setTimeout(function() {
+    done();
+  }, 0);
+});
 QUnit.test('processTree: no closing tag', function(assert) {
   var serializer = new HTMLSerializer();
   var img = document.createElement('img');


### PR DESCRIPTION
When the extension is run on a given page more than once before the page is refreshed, the following error occurs:

 'Identifier "HTMLSerializer" has already been declared' error.

This change fixes the issue.  I don't know if this is the best solution.  Let me know if there is a better way to do this.
