### PR TITLE
Move quotations

### DIFF
--- a/content_script.js
+++ b/content_script.js
@@ -219,10 +219,11 @@ var HTMLSerializer = class {
    */
   processSrcHole(element) {
     var src = element.attributes.src;
-    this.html.push(`${src.name}=`);
+    var quote = this.escapedQuote(this.windowDepth(window));
+    this.html.push(`${src.name}=${quote}`);
     this.srcHoles[this.html.length] = this.fullyQualifiedURL(element).href;
     this.html.push(''); // Entry where data url will go.
-    this.html.push(' '); // Add a space before the next attribute.
+    this.html.push(quote + ' '); // Add a space before the next attribute.
   }
 
   /**
@@ -319,9 +320,7 @@ function fillSrcHoles(htmlSerializer, callback) {
     }).then(function(blob) {
       var reader = new FileReader();
       reader.onload = function(e) {
-        var windowDepth = htmlSerializer.windowDepth(window);
-        var quote = htmlSerializer.escapedQuote(windowDepth);
-        htmlSerializer.html[index] = quote + e.target.result + quote;
+        htmlSerializer.html[index] = e.target.result;
         fillSrcHoles(htmlSerializer, callback);
       }
       reader.readAsDataURL(blob);

--- a/content_script.js
+++ b/content_script.js
@@ -147,10 +147,11 @@ var HTMLSerializer = class {
       // TODO(sfine): Ensure this is working by making sure that an iframe
       //              will always have attributes.
       if (element.tagName == 'IFRAME') {
-        this.html.push('srcdoc=');
+        this.html.push('srcdoc=${quote}');
         var name = this.iframeFullyQualifiedName(element.contentWindow);
         this.frameHoles[this.html.length] = name;
         this.html.push(''); // Entry where the iframe contents will go.
+        this.html.push(quote);
       }
     }
   }

--- a/popup.js
+++ b/popup.js
@@ -55,7 +55,7 @@ function outputHTMLString(messages) {
   for (var i = 1; i < messages.length; i++) {
     rootIndex = messages[i].frameIndex === '0' ? i : rootIndex;
   }
-  fillRemainingHoles(messages, rootIndex, 0);
+  fillRemainingHoles(messages, rootIndex);
   return messages[rootIndex].html.join('');
 }
 
@@ -65,38 +65,19 @@ function outputHTMLString(messages) {
  * @param {Array<Object>} messages The response from all of the injected content
  *     scripts.
  * @param {number} i The index of messages to use.
- * @param {number} depth How many parent iframes messages[i] has.
  */
-// TODO(sfine): Generate correct quotation marks in the content_script.js and
-//              remove getQuotes function from popup.js.
-function fillRemainingHoles(messages, i, depth) {
+function fillRemainingHoles(messages, i) {
   var html = messages[i].html;
-  var quotes = getQuotes(depth);
   var frameHoles = messages[i].frameHoles;
   for (var index in frameHoles) {
     if (frameHoles.hasOwnProperty(index)) {
       var frameIndex = frameHoles[index];
       for (var j = 0; j < messages.length; j++) {
         if (messages[j].frameIndex == frameIndex) {
-          fillRemainingHoles(messages, j, depth+1);
-          html[index] = quotes + messages[j].html.join('') + quotes;
+          fillRemainingHoles(messages, j);
+          html[index] = messages[j].html.join('');
         }
       }
     }
-  }
-}
-
-/**
- * Calculate the correct quotes that should be used given how many parent
- * iframes a given frame has.
- *
- * @param {number} depth The number of parent iframes.
- * @return {string} The correctly escaped quotation marks.
- */
-function getQuotes(depth) {
-  if (depth == 0) {
-    return '"';
-  } else {
-    return '&' + new Array(depth).join('amp;') + 'quot;';
   }
 }

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -128,9 +128,9 @@ QUnit.test('processSrcHole: top window', function(assert) {
   var iframe = document.createElement('iframe');
   iframe.setAttribute('src', 'tests.html');
   serializer.processSrcHole(iframe);
-  assert.equal(serializer.html[0], 'src=');
+  assert.equal(serializer.html[0], 'src="');
   assert.equal(serializer.html[1], '');
-  assert.equal(serializer.html[2], ' ');
+  assert.equal(serializer.html[2], '" ');
   assert.equal(serializer.srcHoles[1], window.location.href);
   assert.equal(Object.keys(serializer.srcHoles).length, 1);
 });
@@ -159,9 +159,9 @@ QUnit.test('processSrcAttribute: img', function(assert) {
   var img = document.createElement('img');
   img.setAttribute('src', 'tests.html');
   serializer.processSrcAttribute(img);
-  assert.equal(serializer.html[0], 'src=');
+  assert.equal(serializer.html[0], 'src="');
   assert.equal(serializer.html[1], '');
-  assert.equal(serializer.html[2], ' ');
+  assert.equal(serializer.html[2], '" ');
   assert.equal(serializer.srcHoles[1], window.location.href);
   assert.equal(Object.keys(serializer.srcHoles).length, 1);
 });


### PR DESCRIPTION
In this pull request I moved all of the functionality for determining which quotation marks to use into the methods of HTMLSerializer.  This only consists of refactoring, not new functionality, so it broke a few tests, which I updated.
