### PR TITLE
Fix extension error: 'Permission currentTab...'

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -11,6 +11,6 @@
   },
 
   "permissions": [
-    "currentTab", "http://*/*", "https://*/*"
+    "activeTab", "http://*/*", "https://*/*"
   ]
 }


### PR DESCRIPTION
The currentTab permission isn't listed in the list of permissions:
https://developer.chrome.com/extensions/declare_permissions

This caused an error when loading the extension:
Permission 'currentTab' is unknown or URL pattern is malformed.

This PR switches to the 'activeTab' permission.
