### PR TITLE
Fix bug where anonymous function cant use 'this' variable

### DIFF
--- a/HTMLSerializer.js
+++ b/HTMLSerializer.js
@@ -434,18 +434,19 @@ var HTMLSerializer = class {
       var index = Object.keys(this.srcHoles)[0];
       var src = this.srcHoles[index];
       delete this.srcHoles[index];
+      var serializer = this;
       fetch(src).then(function(response) {
         return response.blob();
       }).then(function(blob) {
         var reader = new FileReader();
         reader.onload = function(e) {
-          this.html[index] = e.target.result;
-          this.fillSrcHoles(callback);
+          serializer.html[index] = e.target.result;
+          serializer.fillSrcHoles(callback);
         }
         reader.readAsDataURL(blob);
       }).catch(function(error) {
         console.log(error);
-        this.fillSrcHoles(callback);
+        serializer.fillSrcHoles(callback);
       });
     }
   }


### PR DESCRIPTION
In fillSrcHoles 'this' was used in a context where it did not refer to the HTMLSerializer.  This threw an error any time a data url was being processed.
