### PR TITLE
Allow line terminators in @font-face declaration

### DIFF
--- a/HTMLSerializer.js
+++ b/HTMLSerializer.js
@@ -404,14 +404,15 @@ var HTMLSerializer = class {
    */
   processCSSFonts(win, href, css) {
     var serializer = this;
-    var fonts = css.match(/@font-face *?{.*?}/g);
+    var fonts = css.match(/@font-face *?{[\s\S]*?}/g);
     if (fonts) {
       var nestingDepth = this.windowDepth(win);
       var escapedQuote = this.escapedCharacter('"', nestingDepth);
       for (var i = 0; i < fonts.length; i++) {
         // Convert url specified in font to fully qualified url.
         var font = fonts[i].replace(/url\("(.*?)"\)/g, function(match, url) {
-          url = serializer.fullyQualifiedFontURL(href, url);
+          // If href is null the url must be a fully qualified url.
+          url = href ? serializer.fullyQualifiedFontURL(href, url) : url;
           return 'url("' + url + '")';
         }).
         replace(/"/g, escapedQuote);
@@ -440,17 +441,6 @@ var HTMLSerializer = class {
       return hrefURL.protocol + url;
     } else if (url.startsWith('/')) {
       return hrefURL.origin + url;
-    } else if (url.startsWith('./')) {
-      href = href.slice(0, href.lastIndexOf('/'));
-      url = url.slice(1, url.length);
-      return href + url;
-    } else if (url.startsWith('../')) {
-      href = href.slice(0, href.lastIndexOf('/'));
-      while (url.startsWith('../')) {
-        href = href.slice(0, href.lastIndexOf('/'));
-        url = url.slice(3, url.length);
-      }
-      return href + '/' + url;
     } else {
       href = href.slice(0, href.lastIndexOf('/'));
       return href + '/' + url;

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -464,29 +464,34 @@ QUnit.test('fullyQualifiedFontURL', function(assert) {
   var url2 = './hello/world/';
   assert.equal(
     serializer.fullyQualifiedFontURL(href, url2),
-    'http://www.example.com/path/hello/world/'
+    'http://www.example.com/path/./hello/world/'
   );
   var url3 = '../hello/world/';
   assert.equal(
     serializer.fullyQualifiedFontURL(href, url3),
-    'http://www.example.com/hello/world/'
+    'http://www.example.com/path/../hello/world/'
   );
   var url4 = 'http://www.google.com/';
   assert.equal(
     serializer.fullyQualifiedFontURL(href, url4),
     'http://www.google.com/'
   );
+  var url5 = 'hello/world/';
+  assert.equal(
+    serializer.fullyQualifiedFontURL(href, url5),
+    'http://www.example.com/path/hello/world/'
+  );
 });
 
 QUnit.test('processCSSFonts', function(assert) {
   var serializer = new HTMLSerializer();
   var cssText = 'body{color:red;}' +
-      '@font-face{font-family:Font;src:url("/hello/")}';
+      '@font-face{font-family:Font;\nsrc:url("/hello/")}';
   var href = 'http://www.example.com/';
   serializer.processCSSFonts(window, href, cssText);
   assert.equal(
     serializer.fontCSS[0],
-    '@font-face{font-family:Font;src:url("http://www.example.com/hello/")}'
+    '@font-face{font-family:Font;\nsrc:url("http://www.example.com/hello/")}'
   );
 });
 

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -483,15 +483,27 @@ QUnit.test('fullyQualifiedFontURL', function(assert) {
   );
 });
 
-QUnit.test('processCSSFonts', function(assert) {
+QUnit.test('processCSSFonts: no line breaks in declaration', function(assert) {
   var serializer = new HTMLSerializer();
   var cssText = 'body{color:red;}' +
-      '@font-face{font-family:Font;\nsrc:url("/hello/")}';
+      '@font-face{font-family:Font;src:url("/hello/")}';
   var href = 'http://www.example.com/';
   serializer.processCSSFonts(window, href, cssText);
   assert.equal(
     serializer.fontCSS[0],
-    '@font-face{font-family:Font;\nsrc:url("http://www.example.com/hello/")}'
+    '@font-face{font-family:Font;src:url("http://www.example.com/hello/")}'
+  );
+});
+
+QUnit.test('processCSSFonts: line breaks in declaration', function(assert) {
+  var serializer = new HTMLSerializer();
+  var cssText = 'body{color:red;}' +
+      '@font-face { font-family:Font;\nsrc:url("/goodbye/")}';
+  var href = 'http://www.url.com/';
+  serializer.processCSSFonts(window, href, cssText);
+  assert.equal(
+    serializer.fontCSS[0],
+    '@font-face { font-family:Font;\nsrc:url("http://www.url.com/goodbye/")}'
   );
 });
 


### PR DESCRIPTION
This pull request is in response to @progers comment that it didn't work on one of the sites he tried (http://dglazkov.com). It was a small fix (line 407), and I changed the tests to test for this scenario. However, I also made a few changes that handle some edge cases that weren't previously handled.
