### PR TITLE
Process srcdoc attributes

### DIFF
--- a/tests/tests.js
+++ b/tests/tests.js
@@ -519,3 +519,20 @@ QUnit.test('loadFonts', function(assert) {
     'https://code.jquery.com/qunit/qunit-2.0.0.css'
   );
 });
+
+QUnit.test('processSrcdocAttribute', function(assert) {
+  var serializer = new HTMLSerializer();
+  var iframe = document.createElement('iframe');
+  iframe.setAttribute('srcdoc', 'some "html"');
+  serializer.processSrcdocAttribute(iframe);
+  assert.equal(serializer.html[0], 'srcdoc="some &quot;html&quot;" ');
+});
+
+QUnit.test('escapedCharacterString', function(assert) {
+  var serializer =  new HTMLSerializer();
+  var str = serializer.escapedCharacterString(`hello &>'<& "`, 2);
+  assert.equal(
+    str,
+    'hello &amp;amp;&amp;gt;&amp;#39;&amp;lt;&amp;amp; &amp;quot;'
+  );
+});


### PR DESCRIPTION
Injecting a content script when 'allFrames: true' only injects into frames that are specified with a 'src' attribute.  Therefore, 'srcdoc' attributes must be handled separately.  This is a large step towards making the extension idempotent.
