### PR TITLE
Add comment specifying original window size

### DIFF
--- a/HTMLSerializer.js
+++ b/HTMLSerializer.js
@@ -209,6 +209,12 @@ var HTMLSerializer = class {
     this.windowWidth = doc.defaultView.innerWidth;
 
     this.html.push('<!DOCTYPE html>\n');
+
+    if (this.iframeFullyQualifiedName(doc.defaultView) == '0') {
+      this.html.push(`<!-- Original window height: ${this.windowHeight}. -->\n`);
+      this.html.push(`<!-- Original window width: ${this.windowWidth}. -->\n`);
+    }
+
     this.loadFonts(doc);
     this.pseudoElementPlaceHolderIndex = this.html.length;
     this.html.push(''); // Entry where pseudo element style tag will go.

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -661,3 +661,16 @@ QUnit.test('processAttributes: escaping characters', function(assert) {
   serializer.processAttributes(div, 'myId');
   assert.equal(serializer.html[2], 'name="&lt;&quot;&gt;" ');
 });
+
+QUnit.test('window size comment', function(assert) {
+  var serializer = new HTMLSerializer();
+  serializer.processDocument(document);
+  assert.equal(
+    serializer.html[1],
+    `<!-- Original window height: ${window.innerHeight}. -->\n`
+  );
+  assert.equal(
+    serializer.html[2],
+    `<!-- Original window width: ${window.innerWidth}. -->\n`
+  );
+});


### PR DESCRIPTION
Originally the plan was to add a script element that would set the window size to be the same as the original window size.  However, because window.resizeTo is disabled by default in Chrome, I simply add a comment to the top of the document.
